### PR TITLE
Prevent skipping any further movies

### DIFF
--- a/nwmovies/nwmovies_player.c
+++ b/nwmovies/nwmovies_player.c
@@ -80,7 +80,7 @@ static int NWMovies_skipmovie(const char *movietitle)
 	FILE *skipfile;
 	char skiplist[128];
 	char *ptr;
-	static int status = 0;
+	int status = 0;
 
 	if ((skipfile = fopen("nwmovies.skip", "r"))) {
 		while (status == 0 && fgets(skiplist, sizeof(skiplist), skipfile)) {


### PR DESCRIPTION
The logic in the function to determine skipping a movie will skip all
remaining movies and even movies played on request due to the static
variable.  Once a movie is skipped, all further movies are skipped.