### PR TITLE
Allow movies to be symbolic links

### DIFF
--- a/nwmovies/nwmovies_player.c
+++ b/nwmovies/nwmovies_player.c
@@ -114,7 +114,7 @@ static char *NWMovies_findmoviefile(const char *movietitle)
 	}
 
 	while ((entry = readdir(dir)) != NULL) {
-		if (entry->d_type == DT_REG) {
+		if (entry->d_type == DT_REG || entry->d_type == DT_LNK) {
 			if (!strcasecmp(tmp, entry->d_name)) {
 				filename = strdup(entry->d_name);
 				break;


### PR DESCRIPTION
When searching for a movie file within the movie directory, accept
regular files and symbolic links as the files may be installed elsewhere
on the system as part of a different package.